### PR TITLE
Active sites homescreen

### DIFF
--- a/__test__/ConnectedHomeScreen.test.js
+++ b/__test__/ConnectedHomeScreen.test.js
@@ -33,8 +33,13 @@ describe("ConnectedHomeScreen", () => {
     expect(store.getActions()).toEqual([{"item": "test", "type": "history-save-injection"}]);
   })
 
-  it("adds saveInj action to props", () => {
+  it("adds nextInjSite action to props", () => {
     homescreen.props().nextInjSite()
     expect(store.getActions()).toEqual([{"type": "sites-next-injection-site"}]);
+  })
+
+  it("adds rotateNSites action to props", () => {
+    homescreen.props().rotateNSites(5)
+    expect(store.getActions()).toEqual([{"type": "sites-rotate-n-sites", number: 5}]);
   })
 });

--- a/__test__/HomeScreen.test.js
+++ b/__test__/HomeScreen.test.js
@@ -1,28 +1,31 @@
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import React from "react";
 import { Button } from "react-native";
 import moment from 'moment';
 import timekeeper from 'timekeeper';
+import GestureRecognizer, { swipeDirections } from "react-native-swipe-gestures";
+
 import { HomeScreen } from "../screens/HomeScreen";
 import CurrentSite from "../components/CurrentSite";
 import PreviousSite from "../components/PreviousSite";
 import injectionsites from "../components/injectionsites";
-// import store from '../redux/store';
 import BodyImages from "../components/BodyImages";
-import GestureRecognizer, { swipeDirections } from "react-native-swipe-gestures";
 
 describe("Homescreen", () => {
   timekeeper.freeze(new Date(1539760000000))
   let hs
   let mockNextInjSite
   let mockSaveInj
+  let mockRotateNSites
 
   beforeEach(() => {
     mockNextInjSite = jest.fn();
     mockSaveInj = jest.fn();
+    mockRotateNSites = jest.fn();
     hs = shallow(<HomeScreen
       saveInj={mockSaveInj}
       nextInjSite={mockNextInjSite}
+      rotateNSites={mockRotateNSites}
       sites={injectionsites}
       history={[{ site: injectionsites[injectionsites.length - 1], time: moment() }]}
     />)
@@ -42,19 +45,20 @@ describe("Homescreen", () => {
       expect(previousSite.props().time).toEqual(time);
     });
     it("wont render a site that is not active", () => {
-      inactive = [
+      let inactive = [
         { part: 'Thigh', side: 'Left', quadrant: 1, active: false, imgNum: 0 },
         { part: 'Thigh', side: 'Left', quadrant: 2, active: true, imgNum: 1 }
       ]
       hs = shallow(<HomeScreen
-        saveInj={mockSaveInj}
-        nextInjSite={mockNextInjSite}
+        rotateNSites={mockRotateNSites}
         sites={inactive}
         history={[{ site: injectionsites[injectionsites.length - 1], time: moment() }]}
       />)
       const currentSite = hs.find(CurrentSite);
       expect(currentSite.length).toEqual(1);
-      expect(currentSite.props().site).toEqual(injectionsites[1]);
+      // expect(hs.props().sites[0].active).toBe(false)
+      expect(mockRotateNSites.mock.calls.length).toBe(1)
+      expect(currentSite.props().site).toEqual(inactive[1]);
     });
   });
 

--- a/__test__/HomeScreen.test.js
+++ b/__test__/HomeScreen.test.js
@@ -41,6 +41,21 @@ describe("Homescreen", () => {
       expect(previousSite.props().site).toEqual(injectionsites[injectionsites.length - 1]);
       expect(previousSite.props().time).toEqual(time);
     });
+    it("wont render a site that is not active", () => {
+      inactive = [
+        { part: 'Thigh', side: 'Left', quadrant: 1, active: false, imgNum: 0 },
+        { part: 'Thigh', side: 'Left', quadrant: 2, active: true, imgNum: 1 }
+      ]
+      hs = shallow(<HomeScreen
+        saveInj={mockSaveInj}
+        nextInjSite={mockNextInjSite}
+        sites={inactive}
+        history={[{ site: injectionsites[injectionsites.length - 1], time: moment() }]}
+      />)
+      const currentSite = hs.find(CurrentSite);
+      expect(currentSite.length).toEqual(1);
+      expect(currentSite.props().site).toEqual(injectionsites[1]);
+    });
   });
 
   describe("Confirm Button", () => {

--- a/__test__/actions.test.js
+++ b/__test__/actions.test.js
@@ -1,5 +1,5 @@
 import { saveInj, resetHistory } from '../redux/actions/history';
-import { nextInjSite, resetSites } from '../redux/actions/sites';
+import { nextInjSite, resetSites, rotateNSites } from '../redux/actions/sites';
 
 describe('actions', () => {
   it('should create an action to save injection', () => {
@@ -24,7 +24,16 @@ describe('actions', () => {
     }
     expect(nextInjSite()).toEqual(expectedAction)
   })
-  
+
+  it('should rotate injection sites by n', () => {
+    const n = 5
+    const expectedAction = {
+      type: 'sites-rotate-n-sites',
+      number: n
+    }
+    expect(rotateNSites(n)).toEqual(expectedAction)
+  })
+
   it('should reset injection sites', () => {
     const expectedAction = {
       type: 'sites-reset-defaults'

--- a/__test__/reducers.test.js
+++ b/__test__/reducers.test.js
@@ -17,6 +17,17 @@ describe('sites reducer', () => {
       })
     ).toEqual({ sites: [2,3,4,5,1], history: [1] })
   })
+  it('should handle sites-rotate-n-sites', () => {
+    expect(
+      reducer({
+        sites: [1,2,3,4,5],
+        history: [1]
+      }, {
+        type: 'sites-rotate-n-sites',
+        number: 3
+      })
+    ).toEqual({ sites: [4,5,1,2,3], history: [1] })
+  })
   it('should handle site reset', () => {
     expect(reducer({
       sites: [3,4,5,1,2],

--- a/redux/actions/sites.js
+++ b/redux/actions/sites.js
@@ -1,11 +1,18 @@
 export function nextInjSite() {
-    return {
-        type: 'sites-next-injection-site'
-    };
+  return {
+    type: 'sites-next-injection-site'
+  };
+}
+
+export function rotateNSites(n) {
+  return {
+    type: 'sites-rotate-n-sites',
+    number: n
+  }
 }
 
 export function resetSites() {
-    return {
-        type: 'sites-reset-defaults'
-    };
+  return {
+    type: 'sites-reset-defaults'
+  };
 }

--- a/redux/reducers/sites.js
+++ b/redux/reducers/sites.js
@@ -9,6 +9,12 @@ export default function sitesReducer (state = defaultSites, action) {
         case 'sites-next-injection-site':
             return [ ...state.slice(1), state[0] ];
 
+        case 'sites-rotate-n-sites':
+            return [
+              ...state.slice(action.number),
+              ...state.slice(0, action.number)
+            ];
+
         case 'sites-reset-defaults':
             return defaultSites;
 

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -6,7 +6,7 @@ import GestureRecognizer, {
 
 import { connect } from 'react-redux'
 import { saveInj, resetHistory } from '../redux/actions/history';
-import { nextInjSite, resetSites } from '../redux/actions/sites';
+import { nextInjSite, resetSites, rotateNSites } from '../redux/actions/sites';
 
 import moment from 'moment';
 import CurrentSite from '../components/CurrentSite';
@@ -17,7 +17,7 @@ import BodyImages from "../components/BodyImages";
 // import injectionsites from '../components/injectionsites';
 
 export class HomeScreen extends React.Component {
-  
+
   nextSite() {
     // const rotatedSites = this.state.sites.slice(1).concat(this.state.sites[0]);
     this.props.nextInjSite();
@@ -38,6 +38,17 @@ export class HomeScreen extends React.Component {
     this.nextSite();
   }
 
+  skipUntilActive() {
+    let self = this
+    let i
+    for(i = 0; i < self.props.sites.length; i++) {
+      if (self.props.sites[i].active === true ) {
+        if (i != 0) { self.props.rotateNSites(i) }
+        return self.props.sites[i]
+      }
+    }
+  }
+
   render() {
     const config = {
       velocityThreshold: 0.05,
@@ -52,7 +63,7 @@ export class HomeScreen extends React.Component {
           </GestureRecognizer>
           <CurrentSite
             id="currentSite"
-            site={this.props.sites[0]}
+            site={this.skipUntilActive()}
           />
           <PreviousSite
             id="previousSite"
@@ -115,7 +126,8 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => {
     return {
         saveInj: (inj) => { dispatch(saveInj(inj)); },
-        nextInjSite: () => { dispatch(nextInjSite()); }
+        nextInjSite: () => { dispatch(nextInjSite()); },
+        rotateNSites: (n) => { dispatch(rotateNSites(n)); }
     };
 }
 


### PR DESCRIPTION
Puts a method into HomeScreen that rotates the current site to the next available active site. 
Creates a new action+reducer to handle skipping n places in the site list. 
100% passing test coverage.
Need to double check that the picture does update with CurrentSite element. Should do. Probably easiest to test when we've connected SettingsScreen to Redux.