### PR TITLE
Settingsscreen redux

### DIFF
--- a/__test__/ConnectedSettingsScreen.test.js
+++ b/__test__/ConnectedSettingsScreen.test.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { CheckBox } from 'react-native-elements';
+import SettingsScreen from '../screens/SettingsScreen';
+import { createMockStore } from 'redux-test-utils';
+
+describe('ConnectedSettingsScreen', () => {
+  let settingsScreen
+  let store
+
+  beforeEach(() => {
+    store = createMockStore({
+      sites: [{part: 'Thigh', active: true}, {part: 'Leg', active: false}]
+    })
+    settingsScreen = shallow(<SettingsScreen store={store} />);
+  });
+
+  it('adds checkSites action to props', () => {
+    settingsScreen.props().checkSites('Buttock', true)
+    expect(store.getActions()).toEqual([{'part': 'Buttock', 'previousCheckedStatus': true, 'type': 'sites-checked'}]);
+  })
+
+});

--- a/__test__/HomeScreen.test.js
+++ b/__test__/HomeScreen.test.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import React from "react";
 import { Button } from "react-native";
 import moment from 'moment';

--- a/__test__/SettingsScreen.test.js
+++ b/__test__/SettingsScreen.test.js
@@ -1,22 +1,34 @@
-import {shallow} from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
-import SettingsScreen from '../screens/SettingsScreen';
+import { SettingsScreen } from '../screens/SettingsScreen';
 import { CheckBox } from 'react-native-elements';
+import injectionsites from "../components/injectionsites";
 
 describe('SettingsScreen', () => {
+  let app
+  let mockCheckSites
+
+  beforeEach(() => {
+    mockCheckSites = jest.fn();
+    app = shallow(<SettingsScreen
+      checkSites={mockCheckSites}
+      sites={injectionsites}
+      />)
+  })
+
   it('checks the existence of a checkbox', () => {
-    const app = shallow(<SettingsScreen />);
-    const checkbox = app.find("#Thigh")
+    let checkbox = app.find("#Thigh")
     expect(checkbox.length).toEqual(1);
     expect(checkbox.props().checked).toEqual(true);
   });
 
   it('changes the state for arms checkbox', () => {
-    const app = shallow(<SettingsScreen />);
     let checkbox = app.find("#Arm");
+    console.log(checkbox.props());
     checkbox.simulate('press');
     checkbox = app.find("#Arm");
+    console.log(checkbox.props());
     expect(checkbox.length).toEqual(1);
-    expect(checkbox.props().checked).toEqual(false);
+    expect(mockCheckSites.mock.calls.length).toBe(1);
   });
 });

--- a/__test__/SettingsScreen.test.js
+++ b/__test__/SettingsScreen.test.js
@@ -24,10 +24,8 @@ describe('SettingsScreen', () => {
 
   it('changes the state for arms checkbox', () => {
     let checkbox = app.find("#Arm");
-    console.log(checkbox.props());
     checkbox.simulate('press');
     checkbox = app.find("#Arm");
-    console.log(checkbox.props());
     expect(checkbox.length).toEqual(1);
     expect(mockCheckSites.mock.calls.length).toBe(1);
   });

--- a/__test__/actions.test.js
+++ b/__test__/actions.test.js
@@ -43,10 +43,12 @@ describe('actions', () => {
 
   it('should change the state of the checkbox', () => {
     const part = 'Thigh'
-    const checked = true
+    const previousCheckedStatus = true
     const expectedAction = {
-      type: 'sites-checked'
+      type: 'sites-checked',
+      part: part,
+      previousCheckedStatus: previousCheckedStatus
     }
-    expect(checkSites()).toEqual(expectedAction)
+    expect(checkSites(part, previousCheckedStatus)).toEqual(expectedAction)
   })
 })

--- a/__test__/actions.test.js
+++ b/__test__/actions.test.js
@@ -1,5 +1,5 @@
 import { saveInj, resetHistory } from '../redux/actions/history';
-import { nextInjSite, resetSites, rotateNSites } from '../redux/actions/sites';
+import { nextInjSite, checkSites, resetSites, rotateNSites } from '../redux/actions/sites';
 
 describe('actions', () => {
   it('should create an action to save injection', () => {
@@ -39,5 +39,14 @@ describe('actions', () => {
       type: 'sites-reset-defaults'
     }
     expect(resetSites()).toEqual(expectedAction)
+  })
+
+  it('should change the state of the checkbox', () => {
+    const part = 'Thigh'
+    const checked = true
+    const expectedAction = {
+      type: 'sites-checked'
+    }
+    expect(checkSites()).toEqual(expectedAction)
   })
 })

--- a/__test__/reducers.test.js
+++ b/__test__/reducers.test.js
@@ -36,6 +36,34 @@ describe('sites reducer', () => {
       type: 'sites-reset-defaults'
     })).toEqual({ sites: injectionsites, history: [1] })
   })
+
+  it('should handle site checked for one part', () => {
+    expect(
+      reducer({
+        sites: [{part: 3, active: true}],
+        history: [1]
+      }, {
+        type: 'sites-checked',
+        part: 3,
+        previousCheckedStatus: true
+      })
+    ).toEqual({ sites: [{part: 3, active: false}], history: [1] })
+  })
+
+  it('should handle site checked for several parts', () => {
+    expect(
+      reducer({
+        sites: [{part: 3, active: true}, {part: 3, active: true}, {part: 1, active: true}],
+        history: [1]
+      }, {
+        type: 'sites-checked',
+        part: 3,
+        previousCheckedStatus: true
+      })
+    ).toEqual({ sites: [{part: 3, active: false},
+              {part: 3, active: false},
+              {part: 1, active: true}], history: [1] })
+  })
 })
 
 describe('history reducer', () => {

--- a/redux/actions/sites.js
+++ b/redux/actions/sites.js
@@ -16,3 +16,11 @@ export function resetSites() {
     type: 'sites-reset-defaults'
   };
 }
+
+export function checkSites(part, previousCheckedStatus) {
+  return {
+    type: 'sites-checked',
+    part: part,
+    previousCheckedStatus: previousCheckedStatus
+  };
+}

--- a/redux/reducers/sites.js
+++ b/redux/reducers/sites.js
@@ -18,6 +18,15 @@ export default function sitesReducer (state = defaultSites, action) {
         case 'sites-reset-defaults':
             return defaultSites;
 
+        case 'sites-checked':
+            let injSitesNew = state.map((site) => {
+              if (site.part === action.part) {
+                site.active = !action.previousCheckedStatus
+              }
+              return site
+            })
+            return injSitesNew
+
         default:
             return state;
     }

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -1,15 +1,14 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { CheckBox } from 'react-native-elements';
+import { connect } from 'react-redux';
+import { checkSites } from '../redux/actions/sites';
 import injectionsites from '../components/injectionsites'
 
-class SettingsScreen extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      sites: injectionsites,
-    };
-  }
+export class SettingsScreen extends React.Component {
+  static navigationOptions = {
+    title: 'Settings'
+  };
 
   onlyUnique(self) {
     let uniqueParts = []
@@ -23,30 +22,18 @@ class SettingsScreen extends Component {
     return uniqueSites;
   }
 
-  check(title, checked) {
-    let injsitesNew = this.state.sites.map((site) => {
-      if (site.part === title) {
-        site.active = !checked
-      }
-      return site
-    })
-    this.setState({
-      sites: injsitesNew
-    })
-  }
-
   render() {
     return (
       <View>
         {
-          this.onlyUnique(this.state.sites).map((cb) => {
+          this.onlyUnique(this.props.sites).map((cb) => {
           return (
             <CheckBox
               key={cb.part}
               id={cb.part}
               title={cb.part}
               checked={cb.active}
-              onPress={() => this.check(cb.part, cb.active)}
+              onPress={() => this.props.checkSites(cb.part, cb.active)}
             />
           )
         })
@@ -56,4 +43,16 @@ class SettingsScreen extends Component {
   }
 };
 
-export default SettingsScreen;
+const mapStateToProps = (state, ownProps) => {
+  return {
+    sites: state.sites
+  };
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    checkSites: (part, previousCheckedStatus) => { dispatch(checkSites(part, previousCheckedStatus)); }
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsScreen);


### PR DESCRIPTION
Good thing: it's updating CurrentSite on the HomeScreen.
Edge cases to cover:
- when you tick the box(es), they rotate because they share the same props for rotating injection sites
- we should make sure that there is still one box checked (and avoid an empty array because it throws an error)
PS: thank you Andrew for the learning experience and your patience.