### PR TITLE
fix: add catch error to HistoryScreen

### DIFF
--- a/screens/HistoryScreen.js
+++ b/screens/HistoryScreen.js
@@ -64,6 +64,9 @@ export class HistoryScreen extends React.Component {
         })
       }
     })
+    .catch(error => {
+      console.log(error);
+    })
   }
 
   render() {


### PR DESCRIPTION
To avoid a warning message, we add a catch on loadData